### PR TITLE
Modernize code for removal of SkinTemplateOutputPageBeforeExec

### DIFF
--- a/HideSection.hooks.php
+++ b/HideSection.hooks.php
@@ -7,7 +7,20 @@
 class HideSectionHooks {
 
     public static function onBeforePageDisplay( OutputPage &$out, Skin &$skin ) {
+        global $wgHideSectionTitleLink;
         $out->addModules( 'ext.hideSection' );
+
+        if ( $wgHideSectionTitleLink ) {
+
+            $hideelem = Html::Rawelement( 'span',
+                 [ 'class' => 'hidesection-head' ],
+            );
+
+            $title = $out->getPageTitle();
+
+            // Append to page title
+            $out->setPageTitle( $title . $hideelem  );
+        }
         return true;
      }
 
@@ -56,35 +69,6 @@ class HideSectionHooks {
                 'options' => array(),
             ];
         }
-
-    }
-
-    public static function onSkinTemplateOutputPageBeforeExec ( &$skin, &$template ) {
-        global $wgHideSectionTitleLink;
-
-        if ($wgHideSectionTitleLink) {
-            $showall  = wfMessage( 'hidesection-showall' )->text();
-            $hideall  = wfMessage( 'hidesection-hideall' )->text();
-            $titleall = wfMessage( 'hidesection-hidealltitle' )->text();
-
-            $linkelem = Html::element('a', [
-                    "class" => "hidesection-all internal",
-                    "data-show" => $showall,
-                    "data-hide" => $hideall,
-                    "title" => $titleall,
-                    "href" => "#`"
-                ],
-                $hideall
-            );
-            $hideelem = Html::Rawelement('span',
-                 array( 'class' => 'hidesection-head' ),
-                '[' . $linkelem . ']'
-            );
-
-            // Append to page title
-            $template->data['title'] .= $hideelem;
-        }
-        return true;
     }
 }
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "HideSection",
-	"version": "2.0",
+	"version": "3.0",
 	"author": "Brent Laabs",
 	"url": "//mediawiki.org/wiki/Extension:HideSection",
 	"descriptionmsg": "hidesection-desc",
@@ -18,10 +18,11 @@
 		],
 		"SkinEditSectionLinks": [
 			"HideSectionHooks::onSkinEditSectionLinks"
-		],
-		"SkinTemplateOutputPageBeforeExec": [
-			"HideSectionHooks::onSkinTemplateOutputPageBeforeExec"
 		]
+	},
+	"config": {
+		"HideSectionTitleLink": false,
+		"HideSectionHideText": false
 	},
 	"ResourceModules": {
 		"ext.hideSection": {
@@ -30,12 +31,17 @@
 			],
 			"styles": [
 				"ext.hidesection.css"
+			],
+			"messages": [
+				"hidesection-showall",
+				"hidesection-hideall",
+				"hidesection-hidealltitle"
 			]
 		}
 	},
 	"ResourceFileModulePaths": {
 		"localBasePath": "resources",
-		"removeExtPath": "HideSection/resources"
+		"remoteExtPath": "HideSection/resources"
 	},
 	"manifest_version": 1
 }

--- a/resources/ext.hidesection.css
+++ b/resources/ext.hidesection.css
@@ -3,6 +3,15 @@
   display: block;
   float: right;
 }
+
+.hidesection-head::before {
+  content: "["
+}
+
+.hidesection-head::after {
+  content: "]"
+}
+
 .hs-hide-H1, .hs-hide-H2, .hs-hide-H3, .hs-hide-H4, .hs-hide-H5, .hs-hide-H6, .hs-hide-H7 {
   display: none;
 }

--- a/resources/ext.hidesection.js
+++ b/resources/ext.hidesection.js
@@ -66,6 +66,19 @@
 	}
 
 	mw.hook( 'wikipage.content' ).add( function () {
+		$('.hidesection-head').each(function() {
+			var showall = mw.message( 'hidesection-showall' ).text();
+            var hideallmsg = mw.message( 'hidesection-hideall' ).text();
+            var titleall = mw.message( 'hidesection-hidealltitle' ).text();
+            var linkelem = $("<a>")
+					.addClass( "hidesection-all" )
+					.addClass( "internal ")
+					.attr( "data-show", showall)
+					.attr( "data-hide", hideallmsg)
+					.attr( "title", titleall)
+					.text( hideallmsg );
+            $(this).append( linkelem );
+		});
 		$('.hidesection-link, .hidesection-image').click( hidesection );
 		$('.hidesection-all').click( hideall );
 	} );


### PR DESCRIPTION
Tested with git master, appears to work.

I generated the hide all link using Javascript because I couldn't find a PHP way of adding arbitrary HTML to the page title. Since the link requires JavaScript to work anyway this shouldn't matter.