### PR TITLE
Add namespaced import for Html

### DIFF
--- a/HideSection.hooks.php
+++ b/HideSection.hooks.php
@@ -1,4 +1,7 @@
 <?php
+
+use MediaWiki\Html\Html;
+
 /**
  * Hooks for extension HideSection.
  * @ingroup Extensions
@@ -22,9 +25,7 @@ class HideSectionHooks {
 
 		if ( $wgHideSectionTitleLink ) {
 
-			$hideelem = Html::Rawelement( 'span',
-				 [ 'class' => 'hidesection-head' ],
-			);
+			$hideelem = Html::element( 'span', [ 'class' => 'hidesection-head' ] );
 
 			$title = $out->getPageTitle();
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ header, any headers below it are automatically hidden.  Additionally, there is a
 
 ## Installation
 
-Requires Mediawiki 1.25 or higher, as we use extension registration. Just do the
-standard phrase in your LocalSettings.php:
+The extension requires Mediawiki 1.40 or higher. Just add the
+standard phrase to your LocalSettings.php:
 
 ```php
 wfLoadExtension( "HideSection" );

--- a/extension.json
+++ b/extension.json
@@ -4,6 +4,9 @@
 	"author": "Brent Laabs",
 	"url": "//mediawiki.org/wiki/Extension:HideSection",
 	"descriptionmsg": "hidesection-desc",
+	"requires": {
+		"MediaWiki": ">= 1.40.0"
+	},
 	"MessagesDirs": {
 		"HideSection": [
 			"i18n"


### PR DESCRIPTION
Fixes 1.44 compatibility.
Raise the MW requirement to 1.40.
Use Html::element instead of the non-existant "Html::Rawelement" method. Improve grammar in README.md.